### PR TITLE
can set config hook function with REACT_APP_HOOK_PROD_CONFIG and REAC…

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -10,6 +10,7 @@
 // @remove-on-eject-end
 
 var path = require('path');
+var fs = require('fs');
 var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var findCacheDir = require('find-cache-dir');
@@ -33,10 +34,17 @@ var env = getClientEnvironment(publicUrl);
 //Get custom configuration for injecting plugins, presets and loaders
 var customConfig = getCustomConfig(false);
 
+// Define config hook function
+var hook = (config) => config;
+if (process.env.REACT_APP_HOOK_DEV_CONFIG) {
+  var hook_file=path.resolve(fs.realpathSync(process.cwd()), process.env.REACT_APP_HOOK_DEV_CONFIG)
+  console.log('Hook Config with ' + hook_file);
+  var hook=require(hook_file);
+}
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
-module.exports = {
+module.exports = hook({
   // This makes the bundle appear split into separate modules in the devtools.
   // We don't use source maps here because they can be confusing:
   // https://github.com/facebookincubator/create-react-app/issues/343#issuecomment-237241875
@@ -225,4 +233,4 @@ module.exports = {
     net: 'empty',
     tls: 'empty'
   }
-};
+});

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -10,6 +10,7 @@
 // @remove-on-eject-end
 
 var path = require('path');
+var fs = require('fs');
 var autoprefixer = require('autoprefixer');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -56,10 +57,18 @@ if (env['process.env.NODE_ENV'] !== '"production"') {
   throw new Error('Production builds must have NODE_ENV=production.');
 }
 
+// Define config hook function
+var hook = (config) => config;
+if (process.env.REACT_APP_HOOK_PROD_CONFIG) {
+  var hook_file=path.resolve(fs.realpathSync(process.cwd()), process.env.REACT_APP_HOOK_PROD_CONFIG)
+  console.log('Hook Config with ' + hook_file);
+  var hook=require(hook_file);
+}
+
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
-module.exports = {
+module.exports = hook({
   // Don't attempt to continue if there are any errors.
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.
@@ -264,4 +273,4 @@ module.exports = {
     net: 'empty',
     tls: 'empty'
   }
-};
+});


### PR DESCRIPTION
…T_APP_HOOK_DEV_CONFIG env vars

For those who want to modify the config without ejecting the module, it permits to specify with env vars REACT_APP_HOOK_PROD_CONFIG and REACT_APP_HOOK_DEV_CONFIG an additional file (for prod or dev) which exports a function that must return the new config. 
ex. in file env: 
`REACT_APP_HOOK_DEV_CONFIG=./config/config.dev.js`

and in file {project_root}/config/config.dev.js:
```
module.exports=(config)=>{
  // add support for jquery on bootstrap
  config.module.loaders.push(
    {
      test: /(bootstrap).+\.(jsx|js)$/,
      loader: 'imports?jQuery=jquery,$=jquery,this=>window'
    });
  // should always return config
  return config;
};
```
