### PR TITLE
Add camelCase to css-loader config

### DIFF
--- a/packages/react-scripts/config/customizers.js
+++ b/packages/react-scripts/config/customizers.js
@@ -60,8 +60,8 @@ module.exports = {
   },
   'CSS_MODULES': {
     config: {
-      dev: 'style!css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss',
-      prod: 'style!css?modules&-autoprefixer&importLoaders=1!postcss'
+      dev: 'style!css?modules&camelCase&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss',
+      prod: 'style!css?modules&camelCase&-autoprefixer&importLoaders=1!postcss'
     }
   }
 }


### PR DESCRIPTION
IMO when using css modules, most people would want `camelCase`, otherwise can fallback to `styles.["camel-case"]` instead of `styles.camelCase`.