### PR TITLE
Add support for additional webpack configuration

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -41,6 +41,17 @@ The generated project comes with SASS, LESS, and CSS modules support by default,
 - ```PORT=3015``` - change default port (supported in CRA by default)
 - ```OPEN_BROWSER=false``` - don't open browser after running webpack server
 
+### Additional Webpack Configuration
+
+You can add additional webpack configuration options by creating a file named `webpack.custom-config.js` in your app directory and exporting an object of the options to be added. For example, `sass-loader` can be configured by exporting `sassLoader` options:
+
+    var path = require('path');
+    module.exports = {
+      sassLoader: {
+        includePaths: [path.resolve(__dirname, "./src")]
+      }
+    }
+
 ### 🤔 Why?
 The ```create-react-app``` app doesn't allow user configuration and modifications for few reasons:
 

--- a/packages/react-scripts/config/merge-custom-config.js
+++ b/packages/react-scripts/config/merge-custom-config.js
@@ -1,0 +1,27 @@
+var fs = require('fs');
+var path = require('path');
+
+function mergeCustomConfig(config) {
+  var customConfigPath = path.resolve('./webpack.custom-config.js');
+  if (fs.existsSync(customConfigPath)) {
+    var customConfig = require(customConfigPath);
+    Object.keys(customConfig).forEach(function (key) {
+      if (config.hasOwnProperty(key) && typeof config[key] === 'object') {
+        if (Array.isArray(config[key])) {
+          if (Array.isArray(customConfig[key])) {
+            config[key] = config[key].concat(customConfig[key]);
+          } else {
+            config[key].push(customConfig[key]);
+          }
+        } else {
+          Object.assign(config[key], customConfig[key]);
+        }
+      } else {
+        config[key] = customConfig[key];
+      }
+    });
+  }
+  return config;
+}
+
+module.exports = mergeCustomConfig;

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ var WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeMod
 var getClientEnvironment = require('./env');
 var paths = require('./paths');
 var getCustomConfig = require('./get-custom-config');
+var mergeCustomConfig = require('./merge-custom-config');
 
 // @remove-on-eject-begin
 // `path` is not used after eject - see https://github.com/facebookincubator/create-react-app/issues/1174
@@ -39,7 +40,7 @@ var customConfig = getCustomConfig(false);
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
-module.exports = {
+module.exports = mergeCustomConfig({
   // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
   // See the discussion in https://github.com/facebookincubator/create-react-app/issues/343.
   devtool: 'cheap-module-source-map',
@@ -239,4 +240,4 @@ module.exports = {
     net: 'empty',
     tls: 'empty'
   }
-};
+});

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -19,6 +19,7 @@ var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
 var getCustomConfig = require('./get-custom-config');
+var mergeCustomConfig = require('./merge-custom-config');
 
 // @remove-on-eject-begin
 // `path` is not used after eject - see https://github.com/facebookincubator/create-react-app/issues/1174
@@ -64,7 +65,7 @@ if (env['process.env'].NODE_ENV !== '"production"') {
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
-module.exports = {
+module.exports = mergeCustomConfig({
   // Don't attempt to continue if there are any errors.
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.
@@ -281,4 +282,4 @@ module.exports = {
     net: 'empty',
     tls: 'empty'
   }
-};
+});


### PR DESCRIPTION
@kitze This PR adds the ability to extend the react-scripts webpack configuration with additional options, specified in a `webpack.custom-config.js` file in the app directory. See the README changes for an example using `sassLoader` options.