### PR TITLE
Transform pre-processed styles into empty objects

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -32,7 +32,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.(js|jsx)$': isEjecting ?
         '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
-      '^.+\\.css$': resolve('config/jest/cssTransform.js'),
+      '^.+\\.(styl|sass|less|css)$': resolve('config/jest/cssTransform.js'),
       '^(?!.*\\.(js|jsx|styl|sass|less|css|json)$)': resolve('config/jest/fileTransform.js'),
     },
     transformIgnorePatterns: [


### PR DESCRIPTION
@kitze @igorsantos07 @andrzejsliwa 

Fixes #51 #49 

Running tests would fail with parsing errors when using style pre-processors, now the tests ignore pre-processed styles using the `cssTransform` jest transformer